### PR TITLE
fix: clean up preset docs classes

### DIFF
--- a/docs/align-content.md
+++ b/docs/align-content.md
@@ -105,11 +105,11 @@ Use `content-around` to distribute rows in a container such that there is an equ
 
 <container>
   <box striped class="grid grid-cols-3 gap-x-24 content-start" fg-color="var(--tw-cyan-fg)" bg-color="var(--tw-cyan-bg)">
-    <div class="bg-cyan-500 ex-box my-32">01</div>
-    <div class="bg-cyan-500 ex-box my-32">02</div>
-    <div class="bg-cyan-500 ex-box my-32">03</div>
-    <div class="bg-cyan-500 ex-box my-32">04</div>
-    <div class="bg-cyan-500 ex-box my-32">05</div>
+    <div class="pd-bg-cyan-500 ex-box my-32">01</div>
+    <div class="pd-bg-cyan-500 ex-box my-32">02</div>
+    <div class="pd-bg-cyan-500 ex-box my-32">03</div>
+    <div class="pd-bg-cyan-500 ex-box my-32">04</div>
+    <div class="pd-bg-cyan-500 ex-box my-32">05</div>
   </box>
 </container>
 

--- a/docs/border-collapse.md
+++ b/docs/border-collapse.md
@@ -12,7 +12,7 @@ Utilities for controlling whether table borders should collapse or be separated.
 Use `border-collapse` to combine adjacent cell borders into a single border when possible. Note that this includes collapsing borders on the top-level `<table>` tag.
 
 <container>
-  <table class="table! border-collapse w-full border pd-border-slate-400 dark:pd-border-slate-500 pd-bg-white dark:pd-bg-slate-800 pd-text-sm pd-shadow-xl">
+  <table class="table! border-collapse w-full pd-border pd-border-slate-400 dark:pd-border-slate-500 pd-bg-white dark:pd-bg-slate-800 pd-text-sm pd-shadow-xl">
     <thead class="pd-bg-slate-50 dark:pd-bg-slate-700">
       <tr>
         <th class="border pd-border-slate-300 dark:pd-border-slate-600 pd-font-semibold p-16 pd-text-slate-900 dark:pd-text-slate-200 text-left">Song</th>
@@ -73,7 +73,7 @@ Use `border-collapse` to combine adjacent cell borders into a single border when
 Use `border-separate` to force each cell to display its own separate borders.
 
 <container>
-  <table class="table! border border-separate! border-spacing-8 w-full  pd-border-slate-400 dark:pd-border-slate-500 pd-bg-white dark:pd-bg-slate-800 pd-text-sm pd-shadow-xl" style="border-collapse: separate;" >
+  <table class="table! pd-border border-separate! border-spacing-8 w-full  pd-border-slate-400 dark:pd-border-slate-500 pd-bg-white dark:pd-bg-slate-800 pd-text-sm pd-shadow-xl" style="border-collapse: separate;" >
     <thead class="pd-bg-slate-50 dark:pd-bg-slate-700">
       <tr>
         <th class="border pd-border-slate-300 dark:pd-border-slate-600 pd-font-semibold p-16 pd-text-slate-900 dark:pd-text-slate-200 text-left">Song</th>

--- a/docs/border-color.md
+++ b/docs/border-color.md
@@ -56,10 +56,10 @@ Use the `border-{side}-{color}` utilities to set the border color for one side o
 
 <container>
   <div class="grid grid-cols-4 gap-16 justify-items-center">
-    <div class="pd-bg-violet-500 h-80 w-80 border-4 rounded-4 pd-border-indigo-200 border-t-indigo-500"></div>
-    <div class="pd-bg-violet-500 h-80 w-80 border-4 rounded-4 pd-border-indigo-200 border-r-indigo-500"></div>
-    <div class="pd-bg-violet-500 h-80 w-80 border-4 rounded-4 pd-border-indigo-200 border-b-indigo-500"></div>
-    <div class="pd-bg-violet-500 h-80 w-80 border-4 rounded-4 pd-border-indigo-200 border-l-indigo-500"></div>
+    <div class="pd-bg-violet-500 h-80 w-80 border-4 rounded-4 pd-border-indigo-200 pd-border-t-indigo-500"></div>
+    <div class="pd-bg-violet-500 h-80 w-80 border-4 rounded-4 pd-border-indigo-200 pd-border-r-indigo-500"></div>
+    <div class="pd-bg-violet-500 h-80 w-80 border-4 rounded-4 pd-border-indigo-200 pd-border-b-indigo-500"></div>
+    <div class="pd-bg-violet-500 h-80 w-80 border-4 rounded-4 pd-border-indigo-200 pd-border-l-indigo-500"></div>
   </div>
 </container>
 
@@ -75,8 +75,8 @@ Use the `border-{x|y}-{color}` utilities to set the border color on two sides of
 
 <container>
   <div class="grid grid-cols-2 gap-16 justify-items-center">
-    <div class="pd-bg-violet-500 h-80 w-80 border-4 rounded-4 pd-border-indigo-200 border-x-indigo-500"></div>
-    <div class="pd-bg-violet-500 h-80 w-80 border-4 rounded-4 pd-border-indigo-200 border-y-indigo-500"></div>
+    <div class="pd-bg-violet-500 h-80 w-80 border-4 rounded-4 pd-border-indigo-200 pd-border-x-indigo-500"></div>
+    <div class="pd-bg-violet-500 h-80 w-80 border-4 rounded-4 pd-border-indigo-200 pd-border-y-indigo-500"></div>
    </div>
 </container>
 

--- a/docs/border-spacing.md
+++ b/docs/border-spacing.md
@@ -19,7 +19,7 @@ Utilities for controlling the spacing between table borders.
 Use `border-spacing` to control the space between the borders of table cells with [separate borders](/border-collapse.md#separate).
 
 <container>
-  <table class="table! border border-separate! border-spacing-8 w-full  pd-border-slate-400 dark:pd-border-slate-500 pd-bg-white dark:pd-bg-slate-800 pd-text-sm pd-shadow-xl" style="border-collapse: separate;" >
+  <table class="table! pd-border border-separate! border-spacing-8 w-full  pd-border-slate-400 dark:pd-border-slate-500 pd-bg-white dark:pd-bg-slate-800 pd-text-sm pd-shadow-xl" style="border-collapse: separate;" >
     <thead class="pd-bg-slate-50 dark:pd-bg-slate-700">
       <tr>
         <th class="border pd-border-slate-300 dark:pd-border-slate-600 pd-font-semibold p-16 pd-text-slate-900 dark:pd-text-slate-200 text-left">Song</th>

--- a/docs/display.md
+++ b/docs/display.md
@@ -132,14 +132,14 @@ Use `grid` to create a grid container.
 
 <container>
   <box striped class="grid grid-cols-4 gap-16" fg-color="var(--tw-cyan-fg)" bg-color="var(--tw-cyan-bg)">
-    <div class="bg-cyan-500 ex-box">01</div>
-    <div class="bg-cyan-500 ex-box">02</div>
-    <div class="bg-cyan-500 ex-box">03</div>
-    <div class="bg-cyan-500 ex-box">04</div>
-    <div class="bg-cyan-500 ex-box">05</div>
-    <div class="bg-cyan-500 ex-box">06</div>
-    <div class="bg-cyan-500 ex-box">07</div>
-    <div class="bg-cyan-500 ex-box">08</div>
+    <div class="pd-bg-cyan-500 ex-box">01</div>
+    <div class="pd-bg-cyan-500 ex-box">02</div>
+    <div class="pd-bg-cyan-500 ex-box">03</div>
+    <div class="pd-bg-cyan-500 ex-box">04</div>
+    <div class="pd-bg-cyan-500 ex-box">05</div>
+    <div class="pd-bg-cyan-500 ex-box">06</div>
+    <div class="pd-bg-cyan-500 ex-box">07</div>
+    <div class="pd-bg-cyan-500 ex-box">08</div>
   </box>
 </container>
 

--- a/docs/global-components/Container.vue
+++ b/docs/global-components/Container.vue
@@ -12,7 +12,7 @@ onMounted(registerSelf)
 </style>
 
 <template>
-  <section class="py-32 px-16 rounded-8 border pd-border-strictly-temporary-gray pd-bg-gray-100 dark:pd-bg-gray-800" ref="el">
+  <section class="py-32 px-16 rounded-8 pd-border pd-border-strictly-temporary-gray pd-bg-gray-100 dark:pd-bg-gray-800" ref="el">
     <slot />
   </section>
 </template>

--- a/docs/justify-content.md
+++ b/docs/justify-content.md
@@ -51,9 +51,9 @@ Use `justify-end` to justify items against the end of the container’s main axi
 
 <container>
   <box striped class="flex justify-end gap-24 rounded-4" fg-color="var(--tw-cyan-fg)" bg-color="var(--tw-cyan-bg)">
-    <div class="bg-cyan-500 ex-box">01</div>
-    <div class="bg-cyan-500 ex-box">02</div>
-    <div class="bg-cyan-500 ex-box">03</div>
+    <div class="pd-bg-cyan-500 ex-box">01</div>
+    <div class="pd-bg-cyan-500 ex-box">02</div>
+    <div class="pd-bg-cyan-500 ex-box">03</div>
   </box>
 </container>
 

--- a/docs/justify-items.md
+++ b/docs/justify-items.md
@@ -48,22 +48,22 @@ Use `justify-items-end` to justify grid items against the end of their inline ax
 <container>
   <div class="grid grid-cols-3 gap-24">
     <box striped class="flex justify-end rounded-r-4" fg-color="var(--tw-cyan-fg)" bg-color="var(--tw-cyan-bg)">
-      <div class="w-64 bg-cyan-500 ex-box">01</div>
+      <div class="w-64 pd-bg-cyan-500 ex-box">01</div>
     </box>
     <box striped class="flex justify-end rounded-r-4" fg-color="var(--tw-cyan-fg)" bg-color="var(--tw-cyan-bg)">
-      <div class="w-64 bg-cyan-500 ex-box">02</div>
+      <div class="w-64 pd-bg-cyan-500 ex-box">02</div>
     </box>
     <box striped class="flex justify-end rounded-r-4" fg-color="var(--tw-cyan-fg)" bg-color="var(--tw-cyan-bg)">
-      <div class="w-64 bg-cyan-500 ex-box">03</div>
+      <div class="w-64 pd-bg-cyan-500 ex-box">03</div>
     </box>
     <box striped class="flex justify-end rounded-r-4" fg-color="var(--tw-cyan-fg)" bg-color="var(--tw-cyan-bg)">
-      <div class="w-64 bg-cyan-500 ex-box">04</div>
+      <div class="w-64 pd-bg-cyan-500 ex-box">04</div>
     </box>
     <box striped class="flex justify-end rounded-r-4" fg-color="var(--tw-cyan-fg)" bg-color="var(--tw-cyan-bg)">
-      <div class="w-64 bg-cyan-500 ex-box">05</div>
+      <div class="w-64 pd-bg-cyan-500 ex-box">05</div>
     </box>
     <box striped class="flex justify-end rounded-r-4" fg-color="var(--tw-cyan-fg)" bg-color="var(--tw-cyan-bg)">
-      <div class="w-64 bg-cyan-500 ex-box">06</div>
+      <div class="w-64 pd-bg-cyan-500 ex-box">06</div>
     </box>
   </div>
 </container>

--- a/docs/justify-self.md
+++ b/docs/justify-self.md
@@ -41,7 +41,7 @@ Use `justify-self-start` to align a grid item to the start its inline axis.
   <div class="grid grid-cols-3 gap-24">
     <div class="bg-cyan-700 ex-box">01</div>
     <box striped class="flex rounded-l-4" fg-color="var(--tw-cyan-fg)" bg-color="var(--tw-cyan-bg)">
-      <div class="w-64 bg-cyan-500 ex-box">02</div>
+      <div class="w-64 pd-bg-cyan-500 ex-box">02</div>
     </box>
     <div class="bg-cyan-700 ex-box">03</div>
     <div class="bg-cyan-700 ex-box">04</div>

--- a/docs/justify-self.md
+++ b/docs/justify-self.md
@@ -39,14 +39,14 @@ Use `justify-self-start` to align a grid item to the start its inline axis.
 
 <container>
   <div class="grid grid-cols-3 gap-24">
-    <div class="bg-cyan-700 ex-box">01</div>
+    <div class="pd-bg-cyan-700 ex-box">01</div>
     <box striped class="flex rounded-l-4" fg-color="var(--tw-cyan-fg)" bg-color="var(--tw-cyan-bg)">
       <div class="w-64 pd-bg-cyan-500 ex-box">02</div>
     </box>
-    <div class="bg-cyan-700 ex-box">03</div>
-    <div class="bg-cyan-700 ex-box">04</div>
-    <div class="bg-cyan-700 ex-box">05</div>
-    <div class="bg-cyan-700 ex-box">06</div>
+    <div class="pd-bg-cyan-700 ex-box">03</div>
+    <div class="pd-bg-cyan-700 ex-box">04</div>
+    <div class="pd-bg-cyan-700 ex-box">05</div>
+    <div class="pd-bg-cyan-700 ex-box">06</div>
   </div>
 </container>
 

--- a/docs/margin.md
+++ b/docs/margin.md
@@ -107,7 +107,7 @@ To use a negative margin value, prefix the class name with a dash to convert it 
   <div class="relative rounded-xl overflow-auto p-8">
     <div class="flex justify-center ex-font leading-6">
       <div class="flex flex-col items-center">
-        <div class="relative w-128 h-64 pd-bg-sky-400/20 border border-sky-700/10 rounded-4 overflow-hidden"></div>
+        <div class="relative w-128 h-64 pd-bg-sky-400/20 pd-border pd-border-sky-700/10 rounded-4 overflow-hidden"></div>
         <div class="relative -mt-32 pd-bg-sky-500 rounded-4 flex items-center justify-center p-16 pd-shadow-xl">-mt-32</div>
       </div>
     </div>
@@ -115,8 +115,8 @@ To use a negative margin value, prefix the class name with a dash to convert it 
 </container>
 
 ```html
-<div class="w-128 h-64 pd-bg-sky-400 opacity-20 ..."></div>
-<div class="-mt-32 pd-bg-sky-300 ...">-mt-32</div>
+<div class="w-128 h-64 bg-sky-400 opacity-20 ..."></div>
+<div class="-mt-32 bg-sky-300 ...">-mt-32</div>
 ```
 
 ### Hover, focus, and other states

--- a/docs/place-content.md
+++ b/docs/place-content.md
@@ -57,10 +57,10 @@ Use `place-content-end` to to pack items against the end of the block axis.
 
 <container>
   <box striped class="grid grid-cols-[repeat(2,56px)] gap-24 rounded-4 pt-128 place-content-start" fg-color="var(--tw-cyan-fg)" bg-color="var(--tw-cyan-bg)">
-    <div class="bg-cyan-500 ex-box">01</div>
-    <div class="bg-cyan-500 ex-box">02</div>
-    <div class="bg-cyan-500 ex-box">03</div>
-    <div class="bg-cyan-500 ex-box">04</div>
+    <div class="pd-bg-cyan-500 ex-box">01</div>
+    <div class="pd-bg-cyan-500 ex-box">02</div>
+    <div class="pd-bg-cyan-500 ex-box">03</div>
+    <div class="pd-bg-cyan-500 ex-box">04</div>
   </box>
 </container>
 

--- a/docs/place-self.md
+++ b/docs/place-self.md
@@ -65,14 +65,14 @@ Use `place-self-center` to align an item at the center on both axes.
 
 <container>
   <div class="grid grid-cols-3 gap-24">
-    <div class="bg-cyan-600 ex-box h-96">01</div>
+    <div class="pd-bg-cyan-600 ex-box h-96">01</div>
     <box striped class="grid h-96" fg-color="var(--tw-cyan-fg)" bg-color="var(--tw-cyan-bg)">
-      <div class="bg-cyan-500 ex-box h-64 place-self-center">02</div>
+      <div class="pd-bg-cyan-500 ex-box h-64 place-self-center">02</div>
     </box>
-    <div class="bg-cyan-600 ex-box h-96">03</div>
-    <div class="bg-cyan-600 ex-box h-96">04</div>
-    <div class="bg-cyan-600 ex-box h-96">05</div>
-    <div class="bg-cyan-600 ex-box h-96">06</div>
+    <div class="pd-bg-cyan-600 ex-box h-96">03</div>
+    <div class="pd-bg-cyan-600 ex-box h-96">04</div>
+    <div class="pd-bg-cyan-600 ex-box h-96">05</div>
+    <div class="pd-bg-cyan-600 ex-box h-96">06</div>
   </div>
 </container>
 

--- a/docs/pointer-events.md
+++ b/docs/pointer-events.md
@@ -22,7 +22,7 @@ Use `pointer-events-none` to make an element ignore pointer events. The pointer 
             <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd"></path>
           </svg>
         </div>
-        <input type="text" placeholder="Search" class="pd-font-sans block pd-text-sm w-full pl-32 py-8 px-6 border pd-border-slate-900/10 dark:pd-border-slate-100/10 pd-text-slate-500 rounded-8 dark:pd-bg-slate-800 dark:highlight-white/5 dark:pd-text-slate-400">
+        <input type="text" placeholder="Search" class="pd-font-sans block pd-text-sm w-full pl-32 py-8 px-6 pd-border pd-border-slate-900/10 dark:pd-border-slate-100/10 pd-text-slate-500 rounded-8 dark:pd-bg-slate-800 dark:pd-highlight-white/5 dark:pd-text-slate-400">
       </div>
     </div>
     <div class="flex flex-col">
@@ -33,7 +33,7 @@ Use `pointer-events-none` to make an element ignore pointer events. The pointer 
             <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd"></path>
           </svg>
         </div>
-        <input type="text" placeholder="Search" class="pd-font-sans block pd-text-sm w-full pl-32 py-8 px-6 border pd-border-slate-900/10 dark:pd-border-slate-100/10 pd-text-slate-500 rounded-8 dark:pd-bg-slate-800 dark:highlight-white/5 dark:pd-text-slate-400">
+        <input type="text" placeholder="Search" class="pd-font-sans block pd-text-sm w-full pl-32 py-8 px-6 pd-border pd-border-slate-900/10 dark:pd-border-slate-100/10 pd-text-slate-500 rounded-8 dark:pd-bg-slate-800 dark:pd-highlight-white/5 dark:pd-text-slate-400">
       </div>
     </div>
   </div>

--- a/docs/resize.md
+++ b/docs/resize.md
@@ -13,7 +13,7 @@ Use `resize` to make an element horizontally and vertically resizable.
 <container>
   <div class="relative overflow-auto">
     <div class="w-full flex items-center justify-center">
-      <textarea class="resize pd-text-sm p-16 mb-32 w-144 border-1 pd-border-slate-900/10 pd-shadow-xl rounded-8 dark:pd-bg-slate-800 dark:pd-border-slate-100/10 dark:highlight-white/5" rows="3" style="height: 134px; width: 226px;"></textarea>
+      <textarea class="resize pd-text-sm p-16 mb-32 w-144 border-1 pd-border-slate-900/10 pd-shadow-xl rounded-8 dark:pd-bg-slate-800 dark:pd-border-slate-100/10 dark:pd-highlight-white/5" rows="3" style="height: 134px; width: 226px;"></textarea>
     </div>
   </div>
 </container>
@@ -28,7 +28,7 @@ Use `resize-y` to make an element vertically resizable.
 <container>
   <div class="relative overflow-auto">
     <div class="w-full flex items-center justify-center">
-      <textarea class="resize-y pd-text-sm p-16 mb-32 w-144 border-1 pd-border-slate-900/10 pd-shadow-xl rounded-8 dark:pd-bg-slate-800 dark:pd-border-slate-100/10 dark:highlight-white/5" rows="3" style="height: 134px; width: 226px;"></textarea>
+      <textarea class="resize-y pd-text-sm p-16 mb-32 w-144 border-1 pd-border-slate-900/10 pd-shadow-xl rounded-8 dark:pd-bg-slate-800 dark:pd-border-slate-100/10 dark:pd-highlight-white/5" rows="3" style="height: 134px; width: 226px;"></textarea>
     </div>
   </div>
 </container>
@@ -43,7 +43,8 @@ Use `resize-x` to make an element horizontally resizable.
 <container>
   <div class="relative overflow-auto">
     <div class="w-full flex items-center justify-center">
-      <textarea class="resize-x pd-text-sm p-16 mb-32 w-144 border-1 pd-border-slate-900/10 pd-shadow-xl rounded-8 dark:pd-bg-slate-800 dark:pd-border-slate-100/10 dark:highlight-white/5" rows="3" style="height: 134px; width: 226px;"></textarea>
+      <textarea class="resize-x pd-text-sm p-16 mb-32 w-144 border-1 pd-border-slate-900/10 pd-shadow-xl rounded-8 dark:pd-bg-slate-800 dark:pd-border-slate-100/10 dark:pd-highlight-white/5" rows="3" style="height: 134px; width: 226px;">
+      </textarea>
     </div>
   </div>
 </container>
@@ -58,7 +59,7 @@ Use `resize-none` to prevent an element from being resizable.
 <container>
   <div class="relative overflow-auto">
     <div class="w-full flex items-center justify-center">
-      <textarea class="resize-none pd-text-sm p-16 mb-32 w-144 border-1 pd-border-slate-900/10 pd-shadow-xl rounded-8 dark:pd-bg-slate-800 dark:pd-border-slate-100/10 dark:highlight-white/5" rows="3" style="height: 134px; width: 226px;"></textarea>
+      <textarea class="resize-none pd-text-sm p-16 mb-32 w-144 border-1 pd-border-slate-900/10 pd-shadow-xl rounded-8 dark:pd-bg-slate-800 dark:pd-border-slate-100/10 dark:pd-highlight-white/5" rows="3" style="height: 134px; width: 226px;"></textarea>
     </div>
   </div>
 </container>

--- a/docs/scroll-snap-align.md
+++ b/docs/scroll-snap-align.md
@@ -15,7 +15,7 @@ Use the `snap-center` utility to snap an element to its center when being scroll
     <div class="relative">
       <!-- Snap Point -->
       <div class="flex ml-[50%] items-end justify-start pt-32 mb-16">
-        <div class="ml-8 rounded-4 pd-font-mono text-[0.625rem] px-8 pd-bg-indigo-50 pd-text-indigo-600 dark:pd-bg-indigo-500 dark:pd-text-white dark:highlight-white/10">snap point</div>
+        <div class="ml-8 rounded-4 pd-font-mono text-[0.625rem] px-8 pd-bg-indigo-50 pd-text-indigo-600 dark:pd-bg-indigo-500 dark:pd-text-white dark:pd-highlight-white/10">snap point</div>
         <div class="absolute top-0 bottom-0 left-1/2 border-l pd-border-indigo-500"></div>
       </div>
       <!-- Contents -->
@@ -80,7 +80,7 @@ Use the `snap-start` utility to snap an element to its start when being scrolled
       <div class="relative">
         <!-- Snap Point -->
         <div class="ml-0 flex items-end justify-start pt-32 mb-16">
-          <div class="ml-8 rounded-4 pd-font-mono text-[0.625rem] px-8 pd-bg-indigo-50 pd-text-indigo-600 dark:pd-bg-indigo-500 dark:pd-text-white dark:highlight-white/10">snap point</div>
+          <div class="ml-8 rounded-4 pd-font-mono text-[0.625rem] px-8 pd-bg-indigo-50 pd-text-indigo-600 dark:pd-bg-indigo-500 dark:pd-text-white dark:pd-highlight-white/10">snap point</div>
           <div class="absolute top-0 bottom-0 left-0 border-l pd-border-indigo-500"></div>
         </div>
         <!-- Contents -->
@@ -142,7 +142,7 @@ Use the `snap-end` utility to snap an element to its end when being scrolled ins
     <div class="relative">
       <!-- Snap Point -->
       <div class="flex items-end justify-end pt-32 mb-16">
-        <div class="mr-8 rounded-4 pd-font-mono text-[0.625rem] px-8 pd-bg-indigo-50 pd-text-indigo-600 dark:pd-bg-indigo-500 dark:pd-text-white dark:highlight-white/10">snap point</div>
+        <div class="mr-8 rounded-4 pd-font-mono text-[0.625rem] px-8 pd-bg-indigo-50 pd-text-indigo-600 dark:pd-bg-indigo-500 dark:pd-text-white dark:pd-highlight-white/10">snap point</div>
         <div class="absolute top-0 bottom-0 right-0 border-l pd-border-indigo-500"></div>
       </div>
       <!-- Contents -->

--- a/docs/space-between.md
+++ b/docs/space-between.md
@@ -68,9 +68,9 @@ If your elements are in reverse order (using say `flex-row-reverse` or `flex-col
   <div class="relative rounded-xl overflow-auto p-8">
     <div class="flex justify-end ex-font leading-6">
       <box striped class="flex flex-row-reverse space-x-24 space-x-reverse rounded" fg-color="var(--tw-cyan-fg)" bg-color="var(--tw-cyan-bg)">
-        <div class="w-64 h-112 flex items-center justify-center pd-shadow-xl rounded-4 bg-cyan-500">01</div>
-        <div class="w-64 h-112 flex items-center justify-center pd-shadow-xl rounded-4 bg-cyan-500">02</div>
-        <div class="w-64 h-112 flex items-center justify-center pd-shadow-xl rounded-4 bg-cyan-500">03</div>
+        <div class="w-64 h-112 flex items-center justify-center pd-shadow-xl rounded-4 pd-bg-cyan-500">01</div>
+        <div class="w-64 h-112 flex items-center justify-center pd-shadow-xl rounded-4 pd-bg-cyan-500">02</div>
+        <div class="w-64 h-112 flex items-center justify-center pd-shadow-xl rounded-4 pd-bg-cyan-500">03</div>
       </box>
     </div>
   </div>

--- a/docs/table-layout.md
+++ b/docs/table-layout.md
@@ -12,7 +12,7 @@ Utilities for controlling the table layout algorithm.
 Use `table-auto` to allow the table to automatically size columns to fit the contents of the cell.
 
 <container>
-  <table class="table! table-auto border-collapse w-full border pd-border-slate-400 dark:pd-border-slate-500 pd-bg-white dark:pd-bg-slate-800 pd-text-sm pd-shadow-xl">
+  <table class="table! table-auto border-collapse w-full pd-border pd-border-slate-400 dark:pd-border-slate-500 pd-bg-white dark:pd-bg-slate-800 pd-text-sm pd-shadow-xl">
     <thead class="pd-bg-slate-50 dark:pd-bg-slate-700">
       <tr>
         <th class="border pd-border-slate-300 dark:pd-border-slate-600 pd-font-semibold p-16 pd-text-slate-900 dark:pd-text-slate-200 text-left">Song</th>
@@ -75,7 +75,7 @@ Use `table-fixed` to allow the table to ignore the content and use fixed widths 
 You can manually set the widths for some columns and the rest of the available width will be divided evenly amongst the columns without explicit width.
 
 <container>
-  <table class="table! table-fixed border-collapse w-full border pd-border-slate-400 dark:pd-border-slate-500 pd-bg-white dark:pd-bg-slate-800 pd-text-sm pd-shadow-xl">
+  <table class="table! table-fixed border-collapse w-full pd-border pd-border-slate-400 dark:pd-border-slate-500 pd-bg-white dark:pd-bg-slate-800 pd-text-sm pd-shadow-xl">
     <thead class="pd-bg-slate-50 dark:pd-bg-slate-700">
       <tr>
         <th class="border pd-border-slate-300 dark:pd-border-slate-600 pd-font-semibold p-16 pd-text-slate-900 dark:pd-text-slate-200 text-left">Song</th>

--- a/docs/transition-delay.md
+++ b/docs/transition-delay.md
@@ -29,7 +29,7 @@ Use the `delay-{amount}` utilities to control an element’s transition-delay.
   </div>
   <div class="flex flex-col items-center shrink-0">
     <p class="pd-font-medium pd-text-sm pd-text-slate-500 pd-font-mono text-center mb-16 dark:pd-text-slate-400">delay-700</p>
-    <div class="ex-box bg-cyan-500 pd-text-white hover:scale-125 ease-in-out delay-1700 duration-300">Hover me</div>
+    <div class="ex-box pd-bg-cyan-500 pd-text-white hover:scale-125 ease-in-out delay-1700 duration-300">Hover me</div>
   </div>
  </div>
 </container>

--- a/docs/transition-duration.md
+++ b/docs/transition-duration.md
@@ -29,7 +29,7 @@ Use the `duration-{amount}` utilities to control an element’s transition-durat
   </div>
   <div class="flex flex-col items-center shrink-0">
     <p class="pd-font-medium pd-text-sm pd-text-slate-500 pd-font-mono text-center mb-16 dark:pd-text-slate-400">duration-700</p>
-    <div class="ex-box bg-cyan-500 pd-text-white hover:scale-125 ease-in-out duration-700">Hover me</div>
+    <div class="ex-box pd-bg-cyan-500 pd-text-white hover:scale-125 ease-in-out duration-700">Hover me</div>
   </div>
  </div>
 </container>

--- a/docs/user-select.md
+++ b/docs/user-select.md
@@ -12,7 +12,7 @@ Use `select-none` to prevent selecting text in an element and its children.
 
 <container>
   <div class="flex justify-center">
-    <div class="ex-box select-none inline-flex text-center pd-bg-white pd-text-slate-900 pd-font-semibold pd-shadow-xl rounded-8 dark:pd-bg-slate-800 dark:highlight-white/5 dark:pd-text-slate-200 border pd-border-slate-900/5 dark:pd-border-slate-100/5">
+    <div class="ex-box select-none inline-flex text-center pd-bg-white pd-text-slate-900 pd-font-semibold pd-shadow-xl rounded-8 dark:pd-bg-slate-800 dark:pd-highlight-white/5 dark:pd-text-slate-200 pd-border pd-border-slate-900/5 dark:pd-border-slate-100/5">
      The quick smart warp scientist drinks the hazy coffee.
     </div>
   </div>
@@ -29,7 +29,7 @@ Use `select-text` to allow selecting text in an element and its children.
 
 <container>
   <div class="flex justify-center">
-    <div class="ex-box select-text inline-flex text-center pd-bg-white pd-text-slate-900 pd-font-semibold pd-shadow-xl rounded-8 dark:pd-bg-slate-800 dark:highlight-white/5 dark:pd-text-slate-200 border pd-border-slate-900/5 dark:pd-border-slate-100/5">
+    <div class="ex-box select-text inline-flex text-center pd-bg-white pd-text-slate-900 pd-font-semibold pd-shadow-xl rounded-8 dark:pd-bg-slate-800 dark:pd-highlight-white/5 dark:pd-text-slate-200 pd-border pd-border-slate-900/5 dark:pd-border-slate-100/5">
      The quick smart warp scientist drinks the hazy coffee.
     </div>
   </div>
@@ -46,7 +46,7 @@ Use `select-all` to automatically select all the text in an element when a user 
 
 <container>
   <div class="flex justify-center">
-    <div class="ex-box select-all inline-flex text-center pd-bg-white pd-text-slate-900 pd-font-semibold pd-shadow-xl rounded-8 dark:pd-bg-slate-800 dark:highlight-white/5 dark:pd-text-slate-200 border pd-border-slate-900/5 dark:pd-border-slate-100/5">
+    <div class="ex-box select-all inline-flex text-center pd-bg-white pd-text-slate-900 pd-font-semibold pd-shadow-xl rounded-8 dark:pd-bg-slate-800 dark:pd-highlight-white/5 dark:pd-text-slate-200 pd-border pd-border-slate-900/5 dark:pd-border-slate-100/5">
      The quick smart warp scientist drinks the hazy coffee.
     </div>
   </div>
@@ -63,7 +63,7 @@ Use `select-auto` to use the default browser behavior for selecting text. Useful
 
 <container>
   <div class="flex justify-center">
-    <div class="ex-box select-auto inline-flex text-center pd-bg-white pd-text-slate-900 pd-font-semibold pd-shadow-xl rounded-8 dark:pd-bg-slate-800 dark:highlight-white/5 dark:pd-text-slate-200 border pd-border-slate-900/5 dark:pd-border-slate-100/5">
+    <div class="ex-box select-auto inline-flex text-center pd-bg-white pd-text-slate-900 pd-font-semibold pd-shadow-xl rounded-8 dark:pd-bg-slate-800 dark:pd-highlight-white/5 dark:pd-text-slate-200 pd-border pd-border-slate-900/5 dark:pd-border-slate-100/5">
      The quick smart warp scientist drinks the hazy coffee.
     </div>
   </div>

--- a/docs/visibility.md
+++ b/docs/visibility.md
@@ -163,9 +163,9 @@ Use `visible` to make an element visible. This is mostly useful for undoing the 
 
 <container>
   <div class="grid grid-cols-3 gap-16">
-   <div class="ex-box bg-cyan-500 rounded-4">01</div>
-   <div class="ex-box bg-cyan-500 rounded-4 visible">02</div>
-   <div class="ex-box bg-cyan-500 rounded-4">03</div>
+   <div class="ex-box pd-bg-cyan-500 rounded-4">01</div>
+   <div class="ex-box pd-bg-cyan-500 rounded-4 visible">02</div>
+   <div class="ex-box pd-bg-cyan-500 rounded-4">03</div>
   </div>
 </container>
 

--- a/docs/z-index.md
+++ b/docs/z-index.md
@@ -35,7 +35,7 @@ Control the stack order (or three-dimensional positioning) of an element in warp
     <div class="w-80 h-80 rounded-full flex items-center justify-center pd-bg-violet-500 z-30 border">04</div>
     <div class="w-80 h-80 rounded-full flex items-center justify-center pd-bg-indigo-500 z-20 border">05</div>
     <div class="w-80 h-80 rounded-full flex items-center justify-center pd-bg-blue-500 z-10 border">06</div>
-    <div class="w-80 h-80 rounded-full flex items-center justify-center bg-cyan-500 z-0 border">07</div>
+    <div class="w-80 h-80 rounded-full flex items-center justify-center pd-bg-cyan-500 z-0 border">07</div>
   </div>
 </container>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 devDependencies:
   '@itsy/okay':


### PR DESCRIPTION
Examples of fixes

Before|After
---|---
<img width="192" alt="image" src="https://github.com/warp-ds/css-docs/assets/37986637/cf1cd194-f95d-49ef-8962-bbb0bb6a7297">|<img width="220" alt="image" src="https://github.com/warp-ds/css-docs/assets/37986637/af42e5ed-3abb-4e1b-a657-69ae0e0868bf">
<img width="705" alt="image" src="https://github.com/warp-ds/css-docs/assets/37986637/f3bd1aa0-cd72-4edd-a46c-715e88977afd">|<img width="706" alt="image" src="https://github.com/warp-ds/css-docs/assets/37986637/584e0d63-4636-41a8-bf9e-f260bb4a6f61">


