### PR TITLE
fix: set unocss version to 0.54.3 to avoid errors in @warp-ds/uno

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ To get started, you need to install the necessary packages. At the moment, you s
 Below version of `@warp-ds/uno` is compatible with the theme stylesheets mentioned in the [Apply Theme](#_2-apply-theme) section.
 
 ```shell
-npm install unocss @warp-ds/uno@1.0.0-alpha.49
+npm install unocss@0.54.3 @warp-ds/uno@1.0.0-alpha.49
 ```
 
 #### If you are using Webpack


### PR DESCRIPTION
When the latest unocss (0.55.0) is installed with `@warp-ds/uno@1.0.0-alpha.49`, an error is thrown:

``` 
import { escapeSelector, createValueHandler, isString, escapeRegExp, CountableSet, BetterMap } from '@unocss/core';
                                                                     ^^^^^^^^^^^^
SyntaxError: The requested module '@unocss/core' does not provide an export named 'CountableSet'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:128:21)
```
The above error is a result of `@warp-ds/uno` keeping a dependency of `@unocss/core` at a lower version, which seems to be incompatible with the newest unocss version.

Until we update `@warp-ds/uno` dependencies and release a new version of that package, we need to advise users to install a compatible version of `unocss`, which as far as I tested can be `0.54.3`.