### PR TITLE
fix: add docs for animate-spinner

### DIFF
--- a/docs/animation.md
+++ b/docs/animation.md
@@ -18,3 +18,13 @@ Add the `animate-inprogress` utility to add a animated background to indicate th
 ```html
   <button class="animate-inprogress">Save</button>
 ```
+
+### Spinner
+Add the `animate-spinner` utility to add a animated background to indicate that something is loading.
+<container>
+  <div className="animate-spinner"></div>
+</container>
+
+```html
+  <div className="animate-spinner"></div>
+```

--- a/docs/classes.list.js
+++ b/docs/classes.list.js
@@ -22,7 +22,7 @@ export const alignSelf = [
   'self-stretch',
 ];
 
-export const animation = ['animate-inprogress'];
+export const animation = ['animate-inprogress', 'animate-spinner'];
 
 export const appearance = ['appearance-none'];
 


### PR DESCRIPTION
Forgot to add those when the rule was implemented. 

Background: https://sch-chat.slack.com/archives/C04P0GYTHPV/p1693212317185229

Can be found http://localhost:5176/css-docs/animation#animation
![image](https://github.com/warp-ds/css-docs/assets/37986637/543fa3de-6982-43c5-8e37-4f43389aac4d)
