### PR TITLE
fix: remove text from border and background examples

### DIFF
--- a/docs/global-components/qr-color-table.vue
+++ b/docs/global-components/qr-color-table.vue
@@ -26,9 +26,8 @@ const rows = computed(() => props.list ?? data[dataTitle.value])
         <td v-if="desc === null" colspan="2">Unsupported</td>
         <template v-else>
           <td>
-            <div :class="[cls, { 's-bg-primary': /^s-text-inverted/.test(cls) },{ 'border': !/^s-bg/.test(cls) } ]" class="w-64 px-8">
+            <div :class="[cls, { 's-bg-primary': /^s-text-inverted/.test(cls) },{ 'border': !/^s-bg/.test(cls) }, { 'h-24': !/^s-text/.test(cls) } ]" class="w-64 px-8">
               <span v-if="/^s-text/.test(cls)">Text</span>
-              <div v-else class="h-24"></div>
             </div>
           </td>
           <td>

--- a/docs/global-components/qr-color-table.vue
+++ b/docs/global-components/qr-color-table.vue
@@ -26,10 +26,12 @@ const rows = computed(() => props.list ?? data[dataTitle.value])
         <td v-if="desc === null" colspan="2">Unsupported</td>
         <template v-else>
           <td :class="{ 's-text-inverted': /^s-bg-primary-/.test(cls) }">
-            <div :class="[cls, { 's-bg-primary': /^s-text-inverted/.test(cls) }]" class="border w-64 px-8">Text</div>
+            <div :class="[cls, { 's-bg-primary': /^s-text-inverted/.test(cls) },{ 'border': /border|icon|text/.test(cls) } ]" class="w-64 px-8">
+              <span v-if="/text/.test(cls)">Text</span>
+              <div v-else class="h-24"></div>
+            </div>
           </td>
           <td>
-
             <code v-for="(l, i) in desc.split('\n')">
               {{ l }}
               <br v-if="desc.split('\n').length > 1 && i < desc.split('n').length - 1" />

--- a/docs/global-components/qr-color-table.vue
+++ b/docs/global-components/qr-color-table.vue
@@ -25,9 +25,9 @@ const rows = computed(() => props.list ?? data[dataTitle.value])
         <td><code>{{ cls }}</code></td>
         <td v-if="desc === null" colspan="2">Unsupported</td>
         <template v-else>
-          <td :class="{ 's-text-inverted': /^s-bg-primary-/.test(cls) }">
-            <div :class="[cls, { 's-bg-primary': /^s-text-inverted/.test(cls) },{ 'border': /border|icon|text/.test(cls) } ]" class="w-64 px-8">
-              <span v-if="/text/.test(cls)">Text</span>
+          <td>
+            <div :class="[cls, { 's-bg-primary': /^s-text-inverted/.test(cls) },{ 'border': !/^s-bg/.test(cls) } ]" class="w-64 px-8">
+              <span v-if="/^s-text/.test(cls)">Text</span>
               <div v-else class="h-24"></div>
             </div>
           </td>


### PR DESCRIPTION
We don't need to include text in examples for border and background colors. This PR is an attempt to remove the text from those pages.

Before:
![Screenshot 2023-09-04 at 07 40 00](https://github.com/warp-ds/css-docs/assets/41303231/65b7c5cc-ec73-4fc3-841a-a00ba9dce5d7)![Screenshot 2023-09-04 at 07 39 49](https://github.com/warp-ds/css-docs/assets/41303231/1e16736f-08ae-4576-b6ac-f0b8fff93488)

After:
<img width="328" alt="Screenshot 2023-09-04 at 07 40 18" src="https://github.com/warp-ds/css-docs/assets/41303231/ed4f5390-7cac-4a3b-a688-c128b4b3f6e0"><img width="308" alt="Screenshot 2023-09-04 at 07 40 29" src="https://github.com/warp-ds/css-docs/assets/41303231/b6473f4c-b26d-4c6f-b0f7-6a40b0a7aff2">

