### PR TITLE
Fix text background and add icons

### DIFF
--- a/docs/global-components/qr-color-table.vue
+++ b/docs/global-components/qr-color-table.vue
@@ -27,7 +27,7 @@ const rows = computed(() => props.list ?? data[dataTitle.value])
         <td v-if="desc === null" colspan="2">Unsupported</td>
         <template v-else>
           <td>
-            <div :class="[cls, { 's-bg-inverted': /^s-(text|icon)-(inverted)/.test(cls) }, { 's-bg-notification': /^s-text-notification/.test(cls) }, { 'border': !/^s-bg/.test(cls) }, { 'h-24': !/^s-(text|icon)/.test(cls) } ]" class="w-64 px-8 text-center">
+            <div :class="[cls, { 's-bg-inverted': /^s-(text|icon)-inverted/.test(cls) }, { 's-bg-notification': /^s-text-notification/.test(cls) }, { 'border': !/^s-bg/.test(cls) }, { 'h-24': !/^s-(text|icon)/.test(cls) } ]" class="w-64 px-8 text-center">
               <span v-if="/^s-text/.test(cls)">Text</span>
               <icon-search16 v-if="/^s-icon/.test(cls)" class="m-auto my-4"></icon-search16>
             </div>

--- a/docs/global-components/qr-color-table.vue
+++ b/docs/global-components/qr-color-table.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { useData } from 'vitepress'
 import { data } from '../classes.data.js'
 import camelcase from 'camelcase'
+import { IconSearch16 } from '@warp-ds/icons/vue'
 
 const camelcaseify = str => camelcase(str.replace(/[^\w\s]/gi, ''))
 const pageData = useData()
@@ -26,8 +27,9 @@ const rows = computed(() => props.list ?? data[dataTitle.value])
         <td v-if="desc === null" colspan="2">Unsupported</td>
         <template v-else>
           <td>
-            <div :class="[cls, { 's-bg-primary': /^s-text-inverted/.test(cls) },{ 'border': !/^s-bg/.test(cls) }, { 'h-24': !/^s-text/.test(cls) } ]" class="w-64 px-8">
+            <div :class="[cls, { 's-bg-inverted': /^s-(text|icon)-(inverted)/.test(cls) }, { 's-bg-notification': /^s-text-notification/.test(cls) }, { 'border': !/^s-bg/.test(cls) }, { 'h-24': !/^s-(text|icon)/.test(cls) } ]" class="w-64 px-8 text-center">
               <span v-if="/^s-text/.test(cls)">Text</span>
+              <icon-search16 v-if="/^s-icon/.test(cls)" class="m-auto my-4"></icon-search16>
             </div>
           </td>
           <td>

--- a/docs/global-components/qr-color-table.vue
+++ b/docs/global-components/qr-color-table.vue
@@ -29,7 +29,7 @@ const rows = computed(() => props.list ?? data[dataTitle.value])
           <td>
             <div :class="[cls, { 's-bg-inverted': /^s-(text|icon)-inverted/.test(cls) }, { 's-bg-notification': /^s-text-notification/.test(cls) }, { 'border': !/^s-bg/.test(cls) }, { 'h-24': !/^s-(text|icon)/.test(cls) } ]" class="w-64 px-8 text-center">
               <span v-if="/^s-text/.test(cls)">Text</span>
-              <icon-search16 v-if="/^s-icon/.test(cls)" class="m-auto my-4"></icon-search16>
+              <icon-search16 v-if="/^s-icon/.test(cls)" class="m-auto my-4" />
             </div>
           </td>
           <td>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@unocss/core": "^0.55.2",
     "@vueuse/core": "^9.13.0",
     "@warp-ds/eslint-config": "^0.0.1",
+    "@warp-ds/icons": "1.0.0-alpha.1",
     "@warp-ds/preset-docs": "^0.0.16",
     "@warp-ds/uno": "^1.0.0",
     "camelcase": "^7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ devDependencies:
   '@warp-ds/eslint-config':
     specifier: ^0.0.1
     version: 0.0.1(eslint@8.35.0)
+  '@warp-ds/icons':
+    specifier: 1.0.0-alpha.1
+    version: 1.0.0-alpha.1
   '@warp-ds/preset-docs':
     specifier: ^0.0.16
     version: 0.0.16(@warp-ds/uno@1.0.0)
@@ -1033,6 +1036,10 @@ packages:
       eslint: ^8.34.0
     dependencies:
       eslint: 8.35.0
+    dev: true
+
+  /@warp-ds/icons@1.0.0-alpha.1:
+    resolution: {integrity: sha512-sJogTEFfuHugqUOdbaXSJjZgNPee5qDgUVjZGKIHRJEcZgcO+00giZFwu+lRjn+AeUsqsWbg9Zs1+cZkTit5sA==}
     dev: true
 
   /@warp-ds/preset-docs@0.0.16(@warp-ds/uno@1.0.0):


### PR DESCRIPTION
- Show background corresponding to `s-text-` class in Text Color and Icon Color pages
- Show an icon example from @warp-ds/icons in Icon Color page
<img width="684" alt="Screenshot 2023-09-12 at 10 25 18" src="https://github.com/warp-ds/css-docs/assets/41303231/7831c532-9714-48fc-a52b-f5b425f86671">
<img width="690" alt="Screenshot 2023-09-12 at 10 25 06" src="https://github.com/warp-ds/css-docs/assets/41303231/83be9aeb-607c-4cdf-86a0-5e07e6d88ef7">
