### PR TITLE
chore: remove Blocket from ThemeSwitcher

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -48,13 +48,6 @@ export default defineConfig({
       'link',
       {
         rel: 'stylesheet',
-        href: 'https://assets.finn.no/pkg/@warp-ds/fonts/v1/blocket-se.css',
-      },
-    ],
-    [
-      'link',
-      {
-        rel: 'stylesheet',
         href: 'https://assets.finn.no/pkg/@warp-ds/css/v1/tokens/finn-no.css',
       },
     ],

--- a/docs/global-components/ThemeContainer.vue
+++ b/docs/global-components/ThemeContainer.vue
@@ -3,7 +3,6 @@ import { computed } from 'vue';
 
 const themes = {
   'Finn': 'finn-no',
-  'Blocket': 'blocket-se',
   'Tori': 'tori-fi'
 };
 


### PR DESCRIPTION
Blocket brand colors are not yet supported in Warp (we've only copied Finn tokens there for testing purposes). We shouldn't include Blocket in the theme switcher until correct colors are displayed.
<img width="721" alt="Screenshot showing only Finn and Tori in the theme switching select" src="https://github.com/warp-ds/css-docs/assets/41303231/23e43784-aedf-40ec-975b-44d0441722cb">

