### PR TITLE
Improve visual examples for border / divide / outline

### DIFF
--- a/docs/border-style.md
+++ b/docs/border-style.md
@@ -1,6 +1,7 @@
 > Borders
 
 # Border Style
+
 Utilities for controlling the style of an element's borders.
 
 ## Quick reference
@@ -8,14 +9,15 @@ Utilities for controlling the style of an element's borders.
 <qr-table />
 
 ## Basic usage
+
 ### Setting the border style
 Use `border-{style}` to control an element’s border style.
 
 <container>
   <div class="grid grid-cols-3 gap-16 justify-items-center">
-    <div class="pd-bg-pink-500 p-24 rounded-8 border-1 border-solid">01</div>
-    <div class="pd-bg-pink-500 p-24 rounded-8 border-1 border-dashed">02</div>
-    <div class="pd-bg-pink-500 p-24 rounded-8 border-1 border-dotted">03</div>
+    <div class="pd-border-pink-900 pd-bg-pink-100 p-24 rounded-8 border-4 border-solid">01</div>
+    <div class="pd-border-pink-900 pd-bg-pink-100 p-24 rounded-8 border-4 border-dashed">02</div>
+    <div class="pd-border-pink-900 pd-bg-pink-100 p-24 rounded-8 border-4 border-dotted">03</div>
   </div>
 </container>
 
@@ -32,12 +34,12 @@ This is most commonly used to remove a border style that was applied at a smalle
 
 <container>
   <div class="grid gap-16 justify-items-center">
-    <div class="pd-bg-pink-500 p-24 rounded-8 border-1 border-none">No border here!</div>
+    <div class="pd-bg-pink-200 p-24 rounded-8 border-4 border-none">No border here!</div>
   </div>
 </container>
 
 ```html
-    <div class="border-none ...">01</div>
+    <div class="border-4 border-none ...">01</div>
 ```
 
 ### Hover, focus, and other states

--- a/docs/border-width.md
+++ b/docs/border-width.md
@@ -1,6 +1,7 @@
 > Borders
 
 # Border Width
+
 Utilities for controlling the border width of an element.
 
 ## Quick reference
@@ -36,10 +37,10 @@ Use the `border-0`, `border`, `border-2`, `border-4`, or `border-8` utilities to
     <div>border-2</div>
     <div>border-4</div>
     <div>border-8</div>
-    <div class="pd-bg-violet-500 h-80 w-80 border"></div>
-    <div class="pd-bg-violet-500 h-80 w-80 border-2"></div>
-    <div class="pd-bg-violet-500 h-80 w-80 border-4"></div>
-    <div class="pd-bg-violet-500 h-80 w-80 border-8"></div>
+    <div class="pd-bg-violet-100 pd-border-violet-900 h-80 w-80 border"></div>
+    <div class="pd-bg-violet-100 pd-border-violet-900 h-80 w-80 border-2"></div>
+    <div class="pd-bg-violet-100 pd-border-violet-900 h-80 w-80 border-4"></div>
+    <div class="pd-bg-violet-100 pd-border-violet-900 h-80 w-80 border-8"></div>
   </div>
 </container>
 
@@ -59,10 +60,10 @@ Use the `border-{side}`, `border-{side}-0`, `border-{side}-2`, `border-{side}-4`
     <div>border-r-4</div>
     <div>border-b-4</div>
     <div>border-l-4</div>
-    <div class="pd-bg-indigo-500 h-80 w-80 border-t-4"></div>
-    <div class="pd-bg-indigo-500 h-80 w-80 border-r-4"></div>
-    <div class="pd-bg-indigo-500 h-80 w-80 border-b-4"></div>
-    <div class="pd-bg-indigo-500 h-80 w-80 border-l-4"></div>
+    <div class="pd-bg-indigo-100 pd-border-indigo-900 h-80 w-80 border-t-4"></div>
+    <div class="pd-bg-indigo-100 pd-border-indigo-900 h-80 w-80 border-r-4"></div>
+    <div class="pd-bg-indigo-100 pd-border-indigo-900 h-80 w-80 border-b-4"></div>
+    <div class="pd-bg-indigo-100 pd-border-indigo-900 h-80 w-80 border-l-4"></div>
   </div>
 </container>
 
@@ -80,8 +81,8 @@ Use the `border-{x|y}-{width}` utilities to set the border width on two sides of
   <div class="grid grid-cols-2 gap-16 justify-items-center">
     <div>border-x-4</div>
     <div>border-y-4</div>
-    <div class="pd-bg-blue-500 h-80 w-80 border-x-4"></div>
-    <div class="pd-bg-blue-500 h-80 w-80 border-y-4"></div>
+    <div class="pd-bg-blue-100 pd-border-blue-900 h-80 w-80 border-x-4"></div>
+    <div class="pd-bg-blue-100 pd-border-blue-900 h-80 w-80 border-y-4"></div>
   </div>
 </container>
 

--- a/docs/divide-style.md
+++ b/docs/divide-style.md
@@ -10,19 +10,19 @@ This functionality is not yet supported! If you need this, reach out to us on [#
 
 ## Quick reference
 
-| Class                   | Description           |
-|-------------------------|-----------------------|
-| `divide-solid` > * + *  | border-style: solid;  |
-| `divide-dashed` > * + * | border-style: dashed; |
-| `divide-dotted` > * + * | border-style: dotted; |
-| `divide-none` > * + *   | border-style: none;   |
+| Class                       | Description           |
+|-----------------------------|-----------------------|
+| ~~`divide-solid`~~ > * + *  | border-style: solid;  |
+| ~~`divide-dashed`~~ > * + * | border-style: dashed; |
+| ~~`divide-dotted`~~ > * + * | border-style: dotted; |
+| ~~`divide-none`~~ > * + *   | border-style: none;   |
 
 ## Basic usage
 
 ### Set the divide style
 Control the border style between elements using the `divide-{style}` utilities.
 
-<container>
+<!--container>
   <div class="grid gap-16 justify-items-center">
     <div class="pd-bg-pink-500 rounded-8 divide-y divide-dashed w-full max-w-[300]">
       <div class="p-24 text-center">1</div>
@@ -30,7 +30,7 @@ Control the border style between elements using the `divide-{style}` utilities.
       <div class="p-24 text-center">3</div>
     </div>
   </div>
-</container>
+</container-->
 
 ```html
 <div class="divide-y divide-dashed ...">
@@ -40,12 +40,13 @@ Control the border style between elements using the `divide-{style}` utilities.
 </div>
 ```
 
+<!--
 ### Hover, focus, and other states
 Warp lets you conditionally apply utility classes in different states using variant modifiers. For example, use `hover:divide-solid` to only apply the `divide-solid` utility on hover.
 
 ```html
 <div class="divide-y divide-dashed hover:divide-solid">
-  <!-- ... -->
+  ...
 </div>
 ```
 
@@ -54,6 +55,7 @@ You can also use variant modifiers to target media queries like responsive break
 
 ```html
 <div class="divide-y divide-dashed md:divide-solid">
-  <!-- ... -->
+  ...
 </div>
 ```
+-->

--- a/docs/divide-width.md
+++ b/docs/divide-width.md
@@ -1,6 +1,7 @@
 > Borders
 
 # Divide Width
+
 Utilities for controlling the border width between elements.
 
 ## Quick reference
@@ -24,19 +25,19 @@ Add borders between horizontal elements using the `divide-x-{width}` utilities.
 
 <container>
   <div class="grid gap-16 justify-items-center">
-    <div class="flex justify-items-stretch pd-bg-pink-500 rounded-8 divide-x w-full">
-      <div class="p-24 flex-1 text-center">1</div>
-      <div class="p-24 flex-1 text-center">2</div>
-      <div class="p-24 flex-1 text-center">3</div>
+    <div class="flex justify-items-stretch pd-bg-blue-100 s-divide-primary rounded-8 divide-x-4 w-full">
+      <div class="p-24 flex-1 text-center pd-font-mono">01</div>
+      <div class="p-24 flex-1 text-center pd-font-mono">02</div>
+      <div class="p-24 flex-1 text-center pd-font-mono">03</div>
     </div>
   </div>
 </container>
 
-```html
-<div class="divide-x ...">
-  <div>1</div>
-  <div>2</div>
-  <div>3</div>
+```html{1}
+<div class="divide-x-4 ...">
+  <div>01</div>
+  <div>02</div>
+  <div>03</div>
 </div>
 ```
 
@@ -45,19 +46,19 @@ Add borders between stacked elements using the `divide-y-{width}` utilities.
 
 <container>
   <div class="grid gap-16 justify-items-center">
-    <div class="pd-bg-pink-500 rounded-8 divide-y w-full max-w-[300]">
-      <div class="p-24 text-center">1</div>
-      <div class="p-24 text-center">2</div>
-      <div class="p-24 text-center">3</div>
+    <div class="pd-bg-blue-100 s-divide-primary rounded-8 divide-y w-full max-w-[300]">
+      <div class="p-24 text-center pd-font-mono">01</div>
+      <div class="p-24 text-center pd-font-mono">02</div>
+      <div class="p-24 text-center pd-font-mono">03</div>
     </div>
   </div>
 </container>
 
-```html
+```html{1}
 <div class="divide-y ...">
-  <div>1</div>
-  <div>2</div>
-  <div>3</div>
+  <div>01</div>
+  <div>02</div>
+  <div>03</div>
 </div>
 ```
 
@@ -66,19 +67,19 @@ If your elements are in reverse order (using say `flex-row-reverse` or `flex-col
 
 <container>
   <div class="grid gap-16 justify-items-center">
-    <div class="flex flex-col-reverse pd-bg-pink-500 rounded-8 divide-y divide-y-reverse w-full max-w-[300]">
-      <div class="p-24 text-center">1</div>
-      <div class="p-24 text-center">2</div>
-      <div class="p-24 text-center">3</div>
+    <div class="flex flex-col-reverse pd-bg-blue-100 s-divide-primary rounded-8 divide-y divide-y-reverse w-full max-w-[300]">
+      <div class="p-24 text-center pd-font-mono">01</div>
+      <div class="p-24 text-center pd-font-mono">02</div>
+      <div class="p-24 text-center pd-font-mono">03</div>
     </div>
   </div>
 </container>
 
-```html
+```html{1}
 <div class="flex flex-col-reverse divide-y divide-y-reverse ...">
-  <div>1</div>
-  <div>2</div>
-  <div>3</div>
+  <div>01</div>
+  <div>02</div>
+  <div>03</div>
 </div>
 ```
 

--- a/docs/global-components/qr-color-table.vue
+++ b/docs/global-components/qr-color-table.vue
@@ -9,7 +9,7 @@ const pageData = useData();
 const props = defineProps({ list: Array });
 const dataTitle = computed(() => camelcase(pageData.page.value.title.replace(/[^\w\s]/gi, '')));
 const rows = computed(() => props.list ?? data[dataTitle.value]);
-const outlineClasses = 'outline outline-offset-1 outline-2 border';
+const outlineClasses = 'outline outline-4 outline-offset-2 border bg-[--w-gray-200] my-6';
 </script>
 
 <template>

--- a/docs/outline-color.md
+++ b/docs/outline-color.md
@@ -1,6 +1,7 @@
 > Borders
 
 # Outline Color
+
 Utilities for controlling the color of an outline of an element.
 
 ::: tip s-prefix
@@ -16,27 +17,25 @@ The s-prefix (semantic) signals that these will change with the brand css.
 ## Basic usage
 
 ### Setting the outline color
-
 Control the outline color of an element using the `s-outline-{semantic color}` utilities specified in the table above.
 
 <container>
   <div class="grid gap-16 justify-items-center">
-    <div class="s-outline-positive pd-bg-violet-500 h-80 w-80 rounded-4 outline outline-offset-1 outline-2"></div>
+    <div class="s-outline-focused pd-bg-violet-100 h-80 w-80 rounded-4 outline outline-offset-2 outline-4"></div>
   </div>
 </container>
 
 ```html
-<div class="s-outline-positive outline-4 ..."></div>
+<div class="s-outline-focused outline-4 ..."></div>
 ```
 
 ### Hover, focus and other states
-
 Conditionally apply utility classes in different states using variant modifiers.
 For example, use `hover:s-outline-active` to only apply the `s-outline-active` utility on hover.
 
 <container>
   <div class="grid gap-16 justify-items-center">
-    <div class="s-outline hover:s-outline-hover pd-bg-violet-500 h-80 w-80 rounded-4 outline outline-offset-1 outline-2"></div>
+    <div class="s-outline hover:s-outline-hover pd-bg-violet-100 h-80 w-80 rounded-4 outline outline-offset-2 outline-4"></div>
    </div>
 </container>
 
@@ -45,13 +44,12 @@ For example, use `hover:s-outline-active` to only apply the `s-outline-active` u
 ```
 
 ### Breakpoints and media queries
-
 You can also use variant modifiers to target media queries like responsive breakpoints, dark mode, prefers-reduced-motion, and more.
 For example, use `md:s-outline-positive` to apply the `s-outline-positive` utility at only medium screen sizes and above.
 
 <container>
   <div class="grid gap-16 justify-items-center">
-    <div class="s-outline md:s-outline-positive pd-bg-violet-500 h-80 w-80 rounded-4 outline outline-offset-1 outline-2"></div>
+    <div class="s-outline md:s-outline-positive pd-bg-violet-100 h-80 w-80 rounded-4 outline outline-offset-2 outline-4"></div>
    </div>
 </container>
 

--- a/docs/outline-offset.md
+++ b/docs/outline-offset.md
@@ -1,17 +1,18 @@
 > Borders
 
 # Outline Offset
+
 Utilities for controlling the offset of an outline of an element.
 
-
-| Class             | Description                                               |
-| -----------------  | --------------------------------------------------------- |
-| `outline-offset-{size}`  | outline-offset: {size};                                    |
+| Class                   | Description             |
+|-------------------------|-------------------------|
+| `outline-offset-{size}` | outline-offset: {size}; |
 
 > Available values <br />
 > `{size}`: `0`, `1`, `2`, `4`, `8` <br />
 
 ## Basic usage
+
 ### Setting the outline width
 Use the `outline-offset-{size}` utilities to set the outline offset for an element.
 
@@ -21,18 +22,18 @@ Use the `outline-offset-{size}` utilities to set the outline offset for an eleme
     <div>outline-offset-2</div>
     <div>outline-offset-4</div>
     <div>outline-offset-8</div>
-    <div class="pd-bg-violet-500 h-80 w-80 rounded-4 outline outline-offset-1 outline-2"></div>
-    <div class="pd-bg-violet-500 h-80 w-80 rounded-4 outline outline-offset-2 outline-2"></div>
-    <div class="pd-bg-violet-500 h-80 w-80 rounded-4 outline outline-offset-4 outline-2"></div>
-    <div class="pd-bg-violet-500 h-80 w-80 rounded-4 outline outline-offset-8 outline-2"></div>
+    <div class="pd-bg-violet-400 h-80 w-80 rounded-4 outline outline-offset-1 outline-4"></div>
+    <div class="pd-bg-violet-400 h-80 w-80 rounded-4 outline outline-offset-2 outline-4"></div>
+    <div class="pd-bg-violet-400 h-80 w-80 rounded-4 outline outline-offset-4 outline-4"></div>
+    <div class="pd-bg-violet-400 h-80 w-80 rounded-4 outline outline-offset-8 outline-4"></div>
   </div>
 </container>
 
 ```html
-<div class="outline outline-offset-1 outline-2 ..."></div>
-<div class="outline outline-offset-2 outline-2 ..."></div>
-<div class="outline outline-offset-4 outline-2 ..."></div>
-<div class="outline outline-offset-8 outline-2 ..."></div>
+<div class="outline outline-offset-1 outline-4 ..."></div>
+<div class="outline outline-offset-2 outline-4 ..."></div>
+<div class="outline outline-offset-4 outline-4 ..."></div>
+<div class="outline outline-offset-8 outline-4 ..."></div>
 ```
 
 ### Removing outlines

--- a/docs/outline-style.md
+++ b/docs/outline-style.md
@@ -1,41 +1,42 @@
 > Borders
 
 # Outline Style
+
 Utilities for controlling the style of an outline of an element.
 
 ## Quick reference
 
 | Class             | Description                                               |
-| ----------------- | --------------------------------------------------------- |
+|-------------------|-----------------------------------------------------------|
 | `outline-none`    | outline: 2px solid transparent; outline-offset: 2px;      |
 | `outline`         | outline-style: solid;                                     |
 | `outline-dashed`  | outline-style: dashed;                                    |
 | `outline-dotted`  | outline-style: dotted;                                    |
 | `outline-double`  | outline-style: double;                                    |
 
-
 ## Basic usage
+
 ### Setting the outline style
 Use the `outline-{style}` utilities to set the outline style for an element.
 
 <container>
-  <div class="grid grid-cols-4 gap-16 justify-items-center">
-    <div>outline-1</div>
-    <div>outline-2</div>
-    <div>outline-4</div>
-    <div>outline-8</div>
-    <div class="pd-bg-violet-500 h-80 w-80 rounded-4 outline outline-offset-2 outline-2"></div>
-    <div class="pd-bg-violet-500 h-80 w-80 rounded-4 outline-dashed outline-offset-2 outline-2"></div>
-    <div class="pd-bg-violet-500 h-80 w-80 rounded-4 outline-dotted outline-offset-2 outline-2"></div>
-    <div class="pd-bg-violet-500 h-80 w-80 rounded-4 outline-double outline-offset-2 outline-2"></div>
+  <div class="grid grid-cols-4 gap-16 pb-16 justify-items-center">
+    <div>outline</div>
+    <div>outline-dashed</div>
+    <div>outline-dotted</div>
+    <div>outline-double</div>
+    <div class="pd-bg-violet-100 h-80 w-80 rounded-4 outline outline-offset-4 outline-8 outline-[--w-s-color-border-focused]"></div>
+    <div class="pd-bg-violet-100 h-80 w-80 rounded-4 outline-dashed outline-offset-4 outline-8 outline-[--w-s-color-border-focused]"></div>
+    <div class="pd-bg-violet-100 h-80 w-80 rounded-4 outline-dotted outline-offset-4 outline-8 outline-[--w-s-color-border-focused]"></div>
+    <div class="pd-bg-violet-100 h-80 w-80 rounded-4 outline-double outline-offset-4 outline-8 outline-[--w-s-color-border-focused]"></div>
   </div>
 </container>
 
 ```html
-<div class="outline outline-offset-2 outline-2 ..."></div>
-<div class="outline-dashed outline-offset-2 outline-2 ..."></div>
-<div class="outline-dotted outline-offset-2 outline-2 ..."></div>
-<div class="outline-double outline-offset-2 outline-2 ..."></div>
+<div class="outline outline-offset-4 outline-8 ..."></div>
+<div class="outline-dashed outline-offset-4 outline-8 ..."></div>
+<div class="outline-dotted outline-offset-4 outline-8 ..."></div>
+<div class="outline-double outline-offset-4 outline-8 ..."></div>
 ```
 
 ### Removing outlines

--- a/docs/outline-style.md
+++ b/docs/outline-style.md
@@ -25,18 +25,18 @@ Use the `outline-{style}` utilities to set the outline style for an element.
     <div>outline-dashed</div>
     <div>outline-dotted</div>
     <div>outline-double</div>
-    <div class="pd-bg-violet-100 h-80 w-80 rounded-4 outline outline-offset-4 outline-8 outline-[--w-s-color-border-focused]"></div>
-    <div class="pd-bg-violet-100 h-80 w-80 rounded-4 outline-dashed outline-offset-4 outline-8 outline-[--w-s-color-border-focused]"></div>
-    <div class="pd-bg-violet-100 h-80 w-80 rounded-4 outline-dotted outline-offset-4 outline-8 outline-[--w-s-color-border-focused]"></div>
-    <div class="pd-bg-violet-100 h-80 w-80 rounded-4 outline-double outline-offset-4 outline-8 outline-[--w-s-color-border-focused]"></div>
+    <div class="pd-bg-violet-100 h-80 w-80 rounded-4 outline outline-offset-4 outline-4 outline-[--w-s-color-border-focused]"></div>
+    <div class="pd-bg-violet-100 h-80 w-80 rounded-4 outline-dashed outline-offset-4 outline-4 outline-[--w-s-color-border-focused]"></div>
+    <div class="pd-bg-violet-100 h-80 w-80 rounded-4 outline-dotted outline-offset-4 outline-4 outline-[--w-s-color-border-focused]"></div>
+    <div class="pd-bg-violet-100 h-80 w-80 rounded-4 outline-double outline-offset-4 outline-4 outline-[--w-s-color-border-focused]"></div>
   </div>
 </container>
 
 ```html
-<div class="outline outline-offset-4 outline-8 ..."></div>
-<div class="outline-dashed outline-offset-4 outline-8 ..."></div>
-<div class="outline-dotted outline-offset-4 outline-8 ..."></div>
-<div class="outline-double outline-offset-4 outline-8 ..."></div>
+<div class="outline outline-offset-4 outline-4 ..."></div>
+<div class="outline-dashed outline-offset-4 outline-4 ..."></div>
+<div class="outline-dotted outline-offset-4 outline-4 ..."></div>
+<div class="outline-double outline-offset-4 outline-4 ..."></div>
 ```
 
 ### Removing outlines

--- a/docs/outline-width.md
+++ b/docs/outline-width.md
@@ -1,39 +1,41 @@
 > Borders
 
 # Outline Width
+
 Utilities for controlling the outline width of an element.
 
 ## Quick reference
 
 | Class             | Description                                               |
-| ----------------- | --------------------------------------------------------- |
+|-------------------|-----------------------------------------------------------|
 | `outline-{size}`  | outline-width: {size};                                    |
 
 > Available values <br />
 > `{size}`: `0`, `1`, `2`, `4`, `8` <br />
 
 ## Basic usage
+
 ### Setting the outline width
 Use the `outline-{size}` utilities to set the outline width for an element.
 
 <container>
   <div class="grid grid-cols-4 gap-16 justify-items-center">
-    <div>outline-1</div>
+    <div>outline</div>
     <div>outline-2</div>
     <div>outline-4</div>
     <div>outline-8</div>
-    <div class="pd-bg-violet-500 h-80 w-80 rounded-4 outline outline-offset-2 outline-1"></div>
-    <div class="pd-bg-violet-500 h-80 w-80 rounded-4 outline outline-offset-2 outline-2"></div>
-    <div class="pd-bg-violet-500 h-80 w-80 rounded-4 outline outline-offset-2 outline-4"></div>
-    <div class="pd-bg-violet-500 h-80 w-80 rounded-4 outline outline-offset-2 outline-8"></div>
+    <div class="pd-bg-violet-200 h-80 w-80 rounded-4 outline outline-offset-4 outline-1"></div>
+    <div class="pd-bg-violet-200 h-80 w-80 rounded-4 outline outline-offset-4 outline-2"></div>
+    <div class="pd-bg-violet-200 h-80 w-80 rounded-4 outline outline-offset-4 outline-4"></div>
+    <div class="pd-bg-violet-200 h-80 w-80 rounded-4 outline outline-offset-4 outline-8"></div>
   </div>
 </container>
 
 ```html
-<div class="outline outline-offset-2 outline-1 ..."></div>
-<div class="outline outline-offset-2 outline-2 ..."></div>
-<div class="outline outline-offset-2 outline-4 ..."></div>
-<div class="outline outline-offset-2 outline-8 ..."></div>
+<div class="outline outline-offset-4 outline-1 ..."></div>
+<div class="outline outline-offset-4 outline-2 ..."></div>
+<div class="outline outline-offset-4 outline-4 ..."></div>
+<div class="outline outline-offset-4 outline-8 ..."></div>
 ```
 
 ### Hover, focus, and other states


### PR DESCRIPTION
(...and remove confusing examples/info about unsupported divide style)
  
Border style old:
![image](https://github.com/warp-ds/css-docs/assets/7531505/83ccdd2b-6ed7-464f-a4c4-15c3055d21e0)
  
Border style new:
![image](https://github.com/warp-ds/css-docs/assets/7531505/11b258a7-6072-4b00-a743-ac30a08edd12)

  
Border width old:
![image](https://github.com/warp-ds/css-docs/assets/7531505/ef20b87c-8af8-412c-b52a-4479a13d6c54)
  
Border width new:
![image](https://github.com/warp-ds/css-docs/assets/7531505/4f3adfa2-caf0-4901-b29a-d84a1d127441)
  
  
Divide width old:
![image](https://github.com/warp-ds/css-docs/assets/7531505/f0d13b2d-4563-4972-a8f4-910104e660cb)
  
Divide width new:
![image](https://github.com/warp-ds/css-docs/assets/7531505/489b8fa6-ef9c-4ffc-90f2-861b18299527)
  
  
Outline style old:
![image](https://github.com/warp-ds/css-docs/assets/7531505/db482b31-31ba-45ba-9860-9b877312362a)
  
Outline style new:
![image](https://github.com/warp-ds/css-docs/assets/7531505/3a6afa3a-6d10-4aee-a88b-d736cb839161)
  
  
Outline width old:
![image](https://github.com/warp-ds/css-docs/assets/7531505/87801a88-2ba9-4ec6-9f98-4a5587ae0798)
  
Outline width new:
![image](https://github.com/warp-ds/css-docs/assets/7531505/4ef85caa-67fa-452f-97d3-8bc989ffdd53)
  
  
Outline color old:
![image](https://github.com/warp-ds/css-docs/assets/7531505/792902fc-24bb-447c-9fca-55d48df13001)
  
Outline color new:
![image](https://github.com/warp-ds/css-docs/assets/7531505/357c5c97-aac9-4531-8c96-e827223a92f1)
