### PR TITLE
Need important to override Vitepress base font size in prod build

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -6,7 +6,7 @@
 }
 
 html {
-  font-size: 62.5%;
+  font-size: 62.5%!important;
 }
 
 body {


### PR DESCRIPTION

Prod:
![image](https://github.com/warp-ds/css-docs/assets/7531505/2ad89f54-a356-4f4d-8723-cdce8c1b188a)
![image](https://github.com/warp-ds/css-docs/assets/7531505/ab85ba92-1b59-4cf4-8b2a-4a0df064467a)

Local:
![image](https://github.com/warp-ds/css-docs/assets/7531505/d278296c-68fc-4d22-accc-d3866513b94c)
![image](https://github.com/warp-ds/css-docs/assets/7531505/86d9ba4f-962c-4bd1-a298-6513bd0d586b)
