### PR TITLE
docs: warp-428 Add docs for list-position and list-type

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -133,6 +133,8 @@ export default defineConfig({
               link: '/font-variant-numeric',
             },
             { text: 'Line Height', link: '/line-height' },
+            { text: 'List Style Position', link: '/list-style-position' },
+            { text: 'List Style Type', link: '/list-style-type' },
             { text: 'Text Align', link: '/text-align' },
             { text: 'Text Color', link: '/text-color' },
             { text: 'Text Decoration', link: '/text-decoration' },

--- a/docs/classes.list.js
+++ b/docs/classes.list.js
@@ -452,6 +452,17 @@ export const lineHeight = [
   'leading-6',
 ];
 
+export const listStylePosition = [
+  'list-inside',
+  'list-outside',
+];
+
+export const listStyleType = [
+  'list-none',
+  'list-disc',
+  'list-decimal',
+];
+
 export const minWidth = [
   'min-w-0',
   'min-w-full',

--- a/docs/list-style-position.md
+++ b/docs/list-style-position.md
@@ -19,7 +19,7 @@ Control the position of the markers and text indentation in a list using the `li
         <div class="absolute left-32 top-[50] bottom-10 w-1 bg-[var(--tw-pink-fg)]"></div>
         <p class=" mb-3 ml-8 s-text dark:s-text-inverted">list-inside</p>
         <ul class="list-disc !list-inside s-text dark:s-text-inverted s-bg dark:s-bg-inverted rounded-8 !p-16 !pl-32">
-          <li>5 cups of coffee with enough caffein to show how the line breaks</li>
+          <li>5 cups of coffee with enough caffeine to show how the line breaks</li>
           <li>0 cups of tea</li>
           <li>0 cups of water</li>
         </ul>

--- a/docs/list-style-position.md
+++ b/docs/list-style-position.md
@@ -1,0 +1,49 @@
+> Typography
+
+# List Style Position
+
+Utilities for controlling the position of bullets/numbers in lists.
+
+## Quick reference
+
+<qr-table />
+
+## Basic usage
+### ​Setting the list style position
+Control the position of the markers and text indentation in a list using the `list-inside` and `list-outside` utilities.
+
+<container>
+  <div class="relative rounded-8 overflow-auto p-8">
+    <div class="flex flex-col sm:flex-row gap-8">
+      <box class="rounded-4 relative">
+        <div class="absolute left-32 top-[50] bottom-10 w-1 bg-[var(--tw-pink-fg)]"></div>
+        <p class=" mb-3 ml-8 s-text dark:s-text-inverted">list-inside</p>
+        <ul class="list-disc !list-inside s-text dark:s-text-inverted s-bg dark:s-bg-inverted rounded-8 !p-16 !pl-32">
+          <li>5 cups of coffee with enough caffein to show how the line breaks</li>
+          <li>0 cups of tea</li>
+          <li>0 cups of water</li>
+        </ul>
+      </box>
+      <box class="rounded-4 relative">
+        <div class="absolute left-32 top-[50] bottom-10 w-1 bg-[var(--tw-pink-fg)]"></div>
+        <p class=" mb-3 ml-8 s-text dark:s-text-inverted">list-outside</p>
+        <ul class="list-disc !list-outside s-text dark:s-text-inverted s-bg dark:s-bg-inverted rounded-8 !p-16 !pl-32">
+          <li>5 cups of coffee with enough caffein to show how the line breaks</li>
+          <li>0 cups of tea</li>
+          <li>0 cups of water</li>
+        </ul>
+      </box>
+    </div>
+  </div>
+</container>
+
+```html
+<ul class="list-inside ...">
+  <li>5 warp scientists</li>
+  <!-- ... -->
+</ul>
+<ul class="list-outside ...">
+  <li>5 warp scientists</li>
+  <!-- ... -->
+</ul>
+```

--- a/docs/list-style-position.md
+++ b/docs/list-style-position.md
@@ -28,7 +28,7 @@ Control the position of the markers and text indentation in a list using the `li
         <div class="absolute left-32 top-[50] bottom-10 w-1 bg-[var(--tw-pink-fg)]"></div>
         <p class=" mb-3 ml-8 s-text dark:s-text-inverted">list-outside</p>
         <ul class="list-disc !list-outside s-text dark:s-text-inverted s-bg dark:s-bg-inverted rounded-8 !p-16 !pl-32">
-          <li>5 cups of coffee with enough caffein to show how the line breaks</li>
+          <li>5 cups of coffee with enough caffeine to show how the line breaks</li>
           <li>0 cups of tea</li>
           <li>0 cups of water</li>
         </ul>

--- a/docs/list-style-type.md
+++ b/docs/list-style-type.md
@@ -1,0 +1,57 @@
+> Typography
+
+# List Style Type
+
+Utilities for controlling the bullet/number style of a list.
+
+## Quick reference
+
+<qr-table />
+
+## Basic usage
+### Setting the list style type
+To create bulleted or numeric lists, use the `list-disc` and `list-decimal` utilities.
+
+<container>
+  <div class="flex flex-col gap-8 p-16">
+    <div>
+      <span class="s-text dark:s-text-inverted mb-3">list-disc</span>
+      <ul class="!list-disc !list-inside s-text dark:s-text-inverted !pl-0">
+        <li>An orbit is a regular, repeating path.</li>
+        <li>Orbiting objects, include planets, moons, asteroids, and manmade devices.</li>
+        <li>Objects orbit each other because of gravity.</li>
+      </ul>
+    </div>
+    <div>
+      <span class="s-text dark:s-text-inverted mb-3">list-decimal</span>
+      <ul class="!list-decimal !list-inside s-text dark:s-text-inverted !pl-0">
+        <li>An orbit is a regular, repeating path.</li>
+        <li>Orbiting objects, include planets, moons, asteroids, and manmade devices.</li>
+        <li>Objects orbit each other because of gravity.</li>
+      </ul>
+    </div>
+    <div>
+      <span class="s-text dark:s-text-inverted mb-3">list-none</span>
+      <ul class="!list-none !list-inside s-text dark:s-text-inverted !pl-0">
+        <li>An orbit is a regular, repeating path.</li>
+        <li>Orbiting objects, include planets, moons, asteroids, and manmade devices.</li>
+        <li>Objects orbit each other because of gravity.</li>
+      </ul>
+    </div>
+  </div>
+</container>
+
+```html
+<ul class="list-disc ...">
+  <li>5 warp scientists</li>
+  <!-- ... -->
+</ul>
+<ul class="list-decimal ...">
+  <li>5 warp scientists</li>
+  <!-- ... -->
+</ul>
+<ul class="list-none ...">
+  <li>5 warp scientists</li>
+  <!-- ... -->
+</ul>
+```


### PR DESCRIPTION
Adds missing docs for list-position:
<img width="1514" alt="image" src="https://github.com/warp-ds/css-docs/assets/462825/ea9991a6-93ff-44d0-a72f-18054d238156">

and list type:
<img width="1599" alt="image" src="https://github.com/warp-ds/css-docs/assets/462825/8011221d-d6e2-4208-bb78-5616c2b8820c">

