### PR TITLE
docs: warp-273 Add docs for backdrop-blur

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -242,6 +242,12 @@ export default defineConfig({
             { text: 'Box Shadow', link: '/box-shadow' },
             { text: 'Opacity', link: '/opacity' },
           ],
+        },        {
+          text: 'Filters',
+          collapsible: true,
+          items: [
+            { text: 'Backdrop Blur', link: '/backdrop-blur' },
+          ],
         },
         {
           text: 'Tables',

--- a/docs/backdrop-blur.md
+++ b/docs/backdrop-blur.md
@@ -1,0 +1,70 @@
+> Filters
+
+# Backdrop Blur
+
+Utilities for applying backdrop blur filters to an element.
+
+## Quick reference
+
+<qr-table />
+
+## Basic usage
+### Blurring behind an element
+Use the `backdrop-blur-{amount?}` utilities to control an element’s backdrop blur.
+
+<container>
+  <div class="flex flex-wrap gap-16">
+    <div class="w-160 relative">
+      <div>backdrop-blur-none</div>
+      <div class="absolute backdrop-blur-none left-24 right-24 top-48 bottom-24 rounded-8 border border-white"></div>
+      <img class="w-144 rounded-16" src="/20s-scientists.jpg" alt="Ai generated picture of warp scientists from the 1920s" />
+    </div>
+    <div class="w-160 relative">
+    <div>backdrop-blur</div>
+      <div class="absolute backdrop-blur left-24 right-24 top-48 bottom-24 rounded-8 border border-white"></div>
+      <img class="w-144 rounded-16" src="/20s-scientists.jpg" alt="Ai generated picture of warp scientists from the 1920s" />
+    </div>
+    <div class="w-160 relative">
+      <div>backdrop-blur-s</div>
+      <div class="absolute backdrop-blur-s left-24 right-24 top-48 bottom-24 rounded-8 border border-white"></div>
+      <img class="w-144 rounded-16" src="/20s-scientists.jpg" alt="Ai generated picture of warp scientists from the 1920s" />
+    </div>
+    <div class="w-160 relative">
+    <div>backdrop-blur-m</div>
+      <div class="absolute backdrop-blur-m left-24 right-24 top-48 bottom-24 rounded-8 border border-white"></div>
+      <img class="w-144 rounded-16" src="/20s-scientists.jpg" alt="Ai generated picture of warp scientists from the 1920s" />
+    </div>
+    <div class="w-160 relative">
+    <div>backdrop-blur-l</div>
+      <div class="absolute backdrop-blur-l left-24 right-24 top-48 bottom-24 rounded-8 border border-white"></div>
+      <img class="w-144 rounded-16" src="/20s-scientists.jpg" alt="Ai generated picture of warp scientists from the 1920s" />
+    </div>
+    <div class="w-160 relative">
+    <div>backdrop-blur-xl</div>
+      <div class="absolute backdrop-blur-xl left-24 right-24 top-48 bottom-24 rounded-8 border border-white"></div>
+      <img class="w-144 rounded-16" src="/20s-scientists.jpg" alt="Ai generated picture of warp scientists from the 1920s" />
+    </div>
+    <div class="w-160 relative">
+    <div>backdrop-blur-xxl</div>
+      <div class="absolute backdrop-blur-xxl left-24 right-24 top-48 bottom-24 rounded-8 border border-white"></div>
+      <img class="w-144 rounded-16" src="/20s-scientists.jpg" alt="Ai generated picture of warp scientists from the 1920s" />
+    </div>
+    <div class="w-160 relative">
+    <div>backdrop-blur-xxxl</div>
+      <div class="absolute backdrop-blur-xxxl left-24 right-24 top-48 bottom-24 rounded-8 border border-white"></div>
+      <img class="w-144 rounded-16" src="/20s-scientists.jpg" alt="Ai generated picture of warp scientists from the 1920s" />
+    </div>
+  </div>
+</container>
+
+```html
+<div class="backdrop-blur-none ...">
+  <!-- ... -->
+</div>
+<div class="backdrop-blur ...">
+  <!-- ... -->
+</div>
+<div class="backdrop-blur-s ...">
+  <!-- ... -->
+</div>
+```

--- a/docs/backdrop-blur.md
+++ b/docs/backdrop-blur.md
@@ -10,7 +10,7 @@ Utilities for applying backdrop blur filters to an element.
 
 ## Basic usage
 ### Blurring behind an element
-Use the `backdrop-blur-{amount?}` utilities to control an element’s backdrop blur.
+Use the `backdrop-blur-{size}` utilities to control an element’s backdrop blur.
 
 <container>
   <div class="flex flex-wrap gap-16">

--- a/docs/classes.list.js
+++ b/docs/classes.list.js
@@ -26,6 +26,17 @@ export const animation = ['animate-inprogress', 'animate-spinner'];
 
 export const appearance = ['appearance-none'];
 
+export const backdropBlur = [
+  'backdrop-blur-none',
+  'backdrop-blur',
+  'backdrop-blur-s',
+  'backdrop-blur-m',
+  'backdrop-blur-l',
+  'backdrop-blur-xl',
+  'backdrop-blur-xxl',
+  'backdrop-blur-xxxl'
+];
+
 export const backgroundAttachment = [
   'bg-fixed',
   'bg-local',


### PR DESCRIPTION
Add missing docs for backdrop-blur. 

notes!

- Ideally these should have been implemented in the form of:  background-blur-4 instead of the t-shirt sizes. 
- Arbitrary value support are not implemented for this (maybe not needed?) 

<img width="1506" alt="image" src="https://github.com/warp-ds/css-docs/assets/462825/7a29bd6b-d8ed-4fbf-9585-e51f16609f27">
