### PR TITLE
docs: jira216 Support for break inside

### DIFF
--- a/docs/break-inside.md
+++ b/docs/break-inside.md
@@ -3,9 +3,6 @@
 # Break Inside
 Utilities for controlling how a column or page should break within an element.
 
-::: danger Unsupported
-This functionality is not yet supported! If you need this, reach out to us on [#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
-:::
 
 ## Quick reference
 


### PR DESCRIPTION
Removes the 'this is nt supported' from the docs